### PR TITLE
gitgrep対応

### DIFF
--- a/Assets/Plugins/ReferenceViewer/Editor/ReferenceViewerMenu.cs
+++ b/Assets/Plugins/ReferenceViewer/Editor/ReferenceViewerMenu.cs
@@ -120,6 +120,38 @@ namespace ReferenceViewer
 
 #endregion
 
+#region Mac/GitGrep
+
+		[MenuItem("Assets/Find References In Project/By GitGrep", true)]
+		static bool IsEnabledByGitGrep()
+		{
+			if (Selection.assetGUIDs == null || Selection.assetGUIDs.Length == 0)
+			{
+				return false;
+			}
+			return true;
+		}
+
+		[MenuItem("Assets/Find References In Project", false, 27)]
+		[MenuItem("Assets/Find References In Project/By GitGrep", false, 27)]
+		public static void FindReferencesByGitGrep()
+		{
+			if (!LoadSettings())
+			{
+				return;
+			}
+
+			string command = "cd {0} && git grep -l {1} | xargs -ITEXT echo {0}/TEXT";
+			Result result = ReferenceViewerProcessor.FindReferencesByCommand(command, settings.GetExcludeExtentions());
+			if (result != null)
+			{
+				result.Type = Result.SearchType.OSX_GitGrep;
+				ReferenceViewerWindow.CreateWindow(result);
+			}
+		}
+
+#endregion
+
 #endif
 
 #if UNITY_EDITOR_WIN

--- a/Assets/Plugins/ReferenceViewer/Editor/ReferenceViewerProcessor.cs
+++ b/Assets/Plugins/ReferenceViewer/Editor/ReferenceViewerProcessor.cs
@@ -7,6 +7,7 @@ This software is released under the MIT License.
 https://opensource.org/licenses/mit-license.php
 */
 
+using System;
 using UnityEngine;
 using UnityEditor;
 using System.IO;
@@ -28,6 +29,10 @@ namespace ReferenceViewer
 			/// Mac/Grep
 			/// </summary>
 			OSX_Grep,
+			/// <summary>
+			/// Mac/GitGrep
+			/// </summary>
+			OSX_GitGrep,
 			/// <summary>
 			/// Win/FindStr
 			/// </summary>
@@ -142,15 +147,16 @@ namespace ReferenceViewer
 					p.StartInfo.UseShellExecute = false;
 					p.StartInfo.RedirectStandardOutput = true;
 					p.Start();
-					while (p.StandardOutput.Peek() >= 0)
+					p.WaitForExit();
+					foreach (var line in p.StandardOutput.ReadToEnd().Split(new[] { Environment.NewLine }, StringSplitOptions.None))
 					{
-						string line = p.StandardOutput.ReadLine();
+						if (string.IsNullOrWhiteSpace(line)) continue;
 
 						// 出力不要な拡張子なら出力しない
 						// Do not output if extensions that do not require output.
+						var extension = Path.GetExtension(line);
 						if (excludeExtentionList != null)
 						{
-							var extension = Path.GetExtension(line);
 							if (excludeExtentionList.Contains(extension))
 							{
 								continue;
@@ -159,7 +165,6 @@ namespace ReferenceViewer
 
 						assetData.AddReference(line.Replace(applicationDataPathWithoutAssets, ""));
 					}
-					p.WaitForExit();
 					p.Close();
 
 #elif UNITY_EDITOR_WIN


### PR DESCRIPTION
git管理しているときに限りますが、grepを使うよりも早く、spotlightよりも正確に結果が表示されるgitignoreを利用する方法を追加しました。