### PR TITLE
metaの中に参照握っているケースに対応

### DIFF
--- a/Assets/Plugins/ReferenceViewer/Editor/ExcludeSettings.cs
+++ b/Assets/Plugins/ReferenceViewer/Editor/ExcludeSettings.cs
@@ -67,7 +67,6 @@ namespace ReferenceViewer
 		public List<string> GetExcludeExtentions()
 		{
 			List<string> excludes = new List<string>(excludeExtentions);
-			excludes.Add(".meta");
 			return excludes;
 		}
 

--- a/Assets/Plugins/ReferenceViewer/Editor/ReferenceViewerProcessor.cs
+++ b/Assets/Plugins/ReferenceViewer/Editor/ReferenceViewerProcessor.cs
@@ -157,6 +157,17 @@ namespace ReferenceViewer
 							}
 						}
 
+						// metaの中に参照を握っているケース
+						if (extension == ".meta")
+						{
+							var assetPath = line.Replace(".meta", "").Replace(applicationDataPathWithoutAssets, "");
+							if (!string.Equals(assetPath, path, StringComparison.OrdinalIgnoreCase))
+							{
+								assetData.AddReference(assetPath);
+							}
+							continue;
+						}
+
 						assetData.AddReference(line.Replace(applicationDataPathWithoutAssets, ""));
 					}
 					p.WaitForExit();


### PR DESCRIPTION
fontのfallbackFontReferencesのように、.metaの中にのみ情報を保持しているケースがあります。
そのため、.metaの中身も検索しつつ、自身のmetaファイルは表示しないようにしました。