### PR TITLE
AssemblyDefinition対応

### DIFF
--- a/Assets/Plugins/ReferenceViewer/ReferenceViewer.asmdef
+++ b/Assets/Plugins/ReferenceViewer/ReferenceViewer.asmdef
@@ -1,0 +1,14 @@
+{
+    "name": "ReferenceViewer",
+    "references": [],
+    "optionalUnityReferences": [],
+    "includePlatforms": [
+        "Editor"
+    ],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": true,
+    "defineConstraints": []
+}

--- a/Assets/Plugins/ReferenceViewer/ReferenceViewer.asmdef.meta
+++ b/Assets/Plugins/ReferenceViewer/ReferenceViewer.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: b60a57f3694cb460f9f46c6ec33006d0
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
AssemblyDefinitionを置いて、ReferenceViewer以下を別アセンブリにすることで
参照の複雑さやコンパイル時間が長くなることを回避しました。