### PR TITLE
検索した瞬間に検索結果が見えていて欲しい

### DIFF
--- a/Assets/Plugins/ReferenceViewer/Editor/AssetReferenceData.cs
+++ b/Assets/Plugins/ReferenceViewer/Editor/AssetReferenceData.cs
@@ -49,7 +49,7 @@ namespace ReferenceViewer
 		public AssetReferenceData(string path) : base(path, isCreateListItem: false)
 		{
 			References = null;
-			IsFoldout = false;
+			IsFoldout = true;
 		}
 
 		public void AddReference(string path)


### PR DESCRIPTION
これは好みの問題がありそうですが、
検索結果が表示された時、折りたたまれている状態で表示されますが、
クリックして中身を確認のが手間なので全てが展開されている状態で表示されたら良いのではないかと思いました。