### PR TITLE
.NET4未満のランタイムバージョン対応

### DIFF
--- a/Assets/Plugins/ReferenceViewer/Editor/ReferenceViewerMenu.cs
+++ b/Assets/Plugins/ReferenceViewer/Editor/ReferenceViewerMenu.cs
@@ -195,7 +195,7 @@ namespace ReferenceViewer
 			}
 
 			string pathEnv = System.Environment.GetEnvironmentVariable("Path", System.EnvironmentVariableTarget.Process);
-			if (string.IsNullOrWhiteSpace(pathEnv))
+			if (pathEnv == null || pathEnv.Trim() == "")
 			{
 				return false;
 			}

--- a/Assets/Plugins/ReferenceViewer/Editor/ReferenceViewerProcessor.cs
+++ b/Assets/Plugins/ReferenceViewer/Editor/ReferenceViewerProcessor.cs
@@ -201,7 +201,7 @@ namespace ReferenceViewer
 			p.WaitForExit();
 			foreach (var line in p.StandardOutput.ReadToEnd().Split(new[] {"\n"}, StringSplitOptions.None))
 			{
-				if (string.IsNullOrWhiteSpace(line)) continue;
+				if (line == null || line.Trim() == "") continue;
 
 				// 出力不要な拡張子なら出力しない
 				// Do not output if extensions that do not require output.


### PR DESCRIPTION
string.IsNullOrWhiteSpaceは.NET4まで使えないので代替実装にする