### PR TITLE
環境毎のコマンド情報をResult.SearchTypeに切り出し

### DIFF
--- a/Assets/Plugins/ReferenceViewer/Editor/ReferenceViewerMenu.cs
+++ b/Assets/Plugins/ReferenceViewer/Editor/ReferenceViewerMenu.cs
@@ -71,8 +71,7 @@ namespace ReferenceViewer
 				return;
 			}
 
-			string command = "mdfind -onlyin '{0}' {1}";
-			Result result = ReferenceViewerProcessor.FindReferencesByCommand(Result.SearchType.OSX_Spotlight, command, settings.GetExcludeExtentions());
+			Result result = ReferenceViewerProcessor.FindReferencesByCommand(Result.SearchType.OSX_Spotlight, settings.GetExcludeExtentions());
 			if (result != null)
 			{
 				ReferenceViewerWindow.CreateWindow(result);
@@ -102,14 +101,7 @@ namespace ReferenceViewer
 				return;
 			}
 
-			string command = "grep {1} -rl '{0}' ";
-			string[] excludes = settings.GetExcludeFiles();
-			for (int i = 0; i < excludes.Length; ++i)
-			{
-				command += string.Format("--exclude='{0}' ", excludes[i]);
-			}
-
-			Result result = ReferenceViewerProcessor.FindReferencesByCommand(Result.SearchType.OSX_Grep, command);
+			Result result = ReferenceViewerProcessor.FindReferencesByCommand(Result.SearchType.OSX_Grep, settings.GetExcludeExtentions());
 			if (result != null)
 			{
 				ReferenceViewerWindow.CreateWindow(result);
@@ -139,8 +131,7 @@ namespace ReferenceViewer
 				return;
 			}
 
-			string command = "git -C '{0}' grep -l {1}";
-			Result result = ReferenceViewerProcessor.FindReferencesByCommand(Result.SearchType.OSX_GitGrep, command, settings.GetExcludeExtentions());
+			Result result = ReferenceViewerProcessor.FindReferencesByCommand(Result.SearchType.OSX_GitGrep, settings.GetExcludeExtentions());
 			if (result != null)
 			{
 				ReferenceViewerWindow.CreateWindow(result);
@@ -174,8 +165,7 @@ namespace ReferenceViewer
 				return;
 			}
 
-			string command = "/M /S {1} *";
-			Result result = ReferenceViewerProcessor.FindReferencesByCommand(Result.SearchType.WIN_FindStr, command, settings.GetExcludeExtentions());
+			Result result = ReferenceViewerProcessor.FindReferencesByCommand(Result.SearchType.WIN_FindStr, settings.GetExcludeExtentions());
 			if (result != null)
 			{
 				ReferenceViewerWindow.CreateWindow(result);
@@ -202,7 +192,7 @@ namespace ReferenceViewer
 			string[] paths = pathEnv.Split(';');
 			foreach (string path in paths)
 			{
-				if (System.IO.File.Exists(System.IO.Path.Combine(path, "git.exe")))
+				if (System.IO.File.Exists(System.IO.Path.Combine(path, Result.SearchType.WIN_GitGrep.Command().Command)))
 				{
 					return true;
 				}
@@ -219,8 +209,7 @@ namespace ReferenceViewer
 				return;
 			}
 
-			string command = "-C \"{0}\" grep -l {1}";
-			Result result = ReferenceViewerProcessor.FindReferencesByCommand(Result.SearchType.WIN_GitGrep, command, settings.GetExcludeExtentions());
+			Result result = ReferenceViewerProcessor.FindReferencesByCommand(Result.SearchType.WIN_GitGrep, settings.GetExcludeExtentions());
 			if (result != null)
 			{
 				ReferenceViewerWindow.CreateWindow(result);

--- a/Assets/Plugins/ReferenceViewer/Editor/Result.cs
+++ b/Assets/Plugins/ReferenceViewer/Editor/Result.cs
@@ -1,0 +1,109 @@
+﻿/*
+unity-reference-viewer
+
+Copyright (c) 2019 ina-amagami (ina@amagamina.jp)
+
+This software is released under the MIT License.
+https://opensource.org/licenses/mit-license.php
+*/
+
+using System;
+using System.Collections.Generic;
+
+namespace ReferenceViewer
+{
+	public class Result
+	{
+		public enum SearchType
+		{
+			/// <summary>
+			/// Mac/Spotlight
+			/// </summary>
+			OSX_Spotlight,
+
+			/// <summary>
+			/// Mac/Grep
+			/// </summary>
+			OSX_Grep,
+
+			/// <summary>
+			/// Mac/GitGrep
+			/// </summary>
+			OSX_GitGrep,
+
+			/// <summary>
+			/// Win/FindStr
+			/// </summary>
+			WIN_FindStr,
+
+			/// <summary>
+			/// Win/GitGrep
+			/// </summary>
+			WIN_GitGrep
+		}
+
+		public SearchType Type { get; set; }
+
+		/// <summary>
+		/// アセット毎の参照情報
+		/// Reference information for each asset.
+		/// </summary>
+		public List<AssetReferenceData> Assets = new List<AssetReferenceData>();
+	}
+
+	public struct CommandInfo
+	{
+		public readonly string Command;
+		public readonly string Arguments;
+		public readonly string NewLine;
+
+		private const string Null = "\0";
+
+		private CommandInfo(string command, string arguments, string newline)
+		{
+			Command = command;
+			Arguments = arguments;
+			NewLine = newline;
+		}
+
+		internal static readonly CommandInfo OSXSpotlit = new CommandInfo("mdfind", "-onlyin '{0}' -0 {1}", Null);
+		internal static readonly CommandInfo OSXGrep = new CommandInfo("grep", "{1} -rl --null '{0}'", Null);
+		internal static readonly CommandInfo OSXGit = new CommandInfo("git", "-C '{0}' grep -z -l {1}", Null);
+		internal static readonly CommandInfo WinFindstr = new CommandInfo("findstr.exe", "/M /S {1} *", Environment.NewLine);
+		internal static readonly CommandInfo WinGit = new CommandInfo("git.exe", "-C \"{0}\" grep -z -l {1}", Null);
+	}
+
+	public static class SearchTypeExtensions
+	{
+		private static readonly Dictionary<Result.SearchType, CommandInfo> Commands =
+			new Dictionary<Result.SearchType, CommandInfo>
+			{
+				{Result.SearchType.OSX_Spotlight, CommandInfo.OSXSpotlit},
+				{Result.SearchType.OSX_Grep, CommandInfo.OSXGrep},
+				{Result.SearchType.OSX_GitGrep, CommandInfo.OSXGit},
+				{Result.SearchType.WIN_FindStr, CommandInfo.WinFindstr},
+				{Result.SearchType.WIN_GitGrep, CommandInfo.WinGit}
+			};
+
+		public static CommandInfo Command(this Result.SearchType searchType)
+		{
+			return Commands[searchType];
+		}
+
+		public static string AppendArguments(this Result.SearchType searchType, List<string> excludes)
+		{
+			if (searchType == Result.SearchType.OSX_Grep)
+			{
+				string appendArguments = string.Empty;
+				foreach (string exclude in excludes)
+				{
+					appendArguments += string.Format(" --exclude='{0}'", exclude);
+				}
+
+				return appendArguments;
+			}
+
+			return string.Empty;
+		}
+	}
+}

--- a/Assets/Plugins/ReferenceViewer/Editor/Result.cs.meta
+++ b/Assets/Plugins/ReferenceViewer/Editor/Result.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 91d02fe22ce2d16458c1518c2a6a5ba3
+timeCreated: 1563635004
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
環境毎のコマンド情報を`Resutl.SearchType`と`CommandInfo`に切り出しました。
また、findstr以外はnull文字区切りで出力できるので区切り文字を変更しています。