### PR TITLE
upmを追加

### DIFF
--- a/Assets/Plugins/ReferenceViewer/package.json
+++ b/Assets/Plugins/ReferenceViewer/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "jp.amagamina.reference-viewer",
+  "version": "1.0.0",
+  "displayName": "unity-reference-viewer",
+  "description": "It's a tool for searching asset references on Unity and displaying them on the window.",
+  "author": "ina-amagami <ina@amagamina.jp>",
+  "dependencies": {}
+}

--- a/Assets/Plugins/ReferenceViewer/package.json.meta
+++ b/Assets/Plugins/ReferenceViewer/package.json.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 1423f0510c544249ab975dc9603774d3
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,18 @@ Unity上でアセットの参照を検索し、ウィンドウ上に表示する
   
 詳しい解説は[**こちら**](https://amagamina.jp/reference-viewer/)
 
+## セットアップ
+
+Unity2019.3.4f1またはUnity2020.1a21以降ならUnityプロジェクトの`Packages/manifest.json`のdepdendenciesセクションに次の行を追加できます。
+
+```json
+{
+  "dependencies": {
+    "jp.amagamina.reference-viewer": "https://github.com/ina-amagami/unity-reference-viewer.git?path=/Assets/Plugins/ReferenceViewer"
+  }
+}
+```
+
 ## ライセンス条項
 
 MITライセンス

--- a/README_EN.md
+++ b/README_EN.md
@@ -10,6 +10,18 @@ It's characterized by whether the GUID of the target asset is included in the fi
   
 It process relatively fast depending on the environment. So doesn't cache results.
 
+## Setup
+
+For Unity2019.3.4f1 or Unity2020.1a21 or higher you can add the following lines to the `Packages/manifest.json` in your Unity Project under the dependencies section:
+
+```json
+{
+  "dependencies": {
+    "jp.amagamina.reference-viewer": "https://github.com/ina-amagami/unity-reference-viewer.git?path=/Assets/Plugins/ReferenceViewer"
+  }
+}
+```
+
 ## How to
 
 Right-click the target asset or directory and select "Find References In Project".


### PR DESCRIPTION
Unity2019.3.4f1とUnity2020.1a21から以下のようにPackage ManagerでgitのURLを指定する際にフォルダを指定できるようになりました。

```json
{
  "dependencies": {
    "jp.amagamina.reference-viewer": "https://github.com/ina-amagami/unity-reference-viewer.git?path=/Assets/Plugins/ReferenceViewer"
  }
}
```

https://forum.unity.com/threads/some-feedback-on-package-manager-git-support.743345/#post-5425311