### PR TITLE
 Unity 2021.2 で表示される警告への対応

### DIFF
--- a/Editor/ReferenceViewerMenu.cs
+++ b/Editor/ReferenceViewerMenu.cs
@@ -62,7 +62,6 @@ namespace ReferenceViewer
 			return true;
 		}
 
-		[MenuItem("Assets/Find References In Project", false, 25)]
 		[MenuItem("Assets/Find References In Project/By Spotlight", false, 25)]
 		public static void FindReferencesBySpotlight()
 		{
@@ -92,7 +91,6 @@ namespace ReferenceViewer
 			return true;
 		}
 		
-		[MenuItem("Assets/Find References In Project", false, 26)]
 		[MenuItem("Assets/Find References In Project/By Grep", false, 26)]
 		public static void FindReferencesByGrep()
 		{
@@ -122,7 +120,6 @@ namespace ReferenceViewer
 			return true;
 		}
 
-		[MenuItem("Assets/Find References In Project", false, 27)]
 		[MenuItem("Assets/Find References In Project/By GitGrep", false, 27)]
 		public static void FindReferencesByGitGrep()
 		{
@@ -156,7 +153,6 @@ namespace ReferenceViewer
 			return true;
 		}
 
-		[MenuItem("Assets/Find References In Project", false, 25)]
 		[MenuItem("Assets/Find References In Project/By FindStr", false, 25)]
 		public static void FindReferencesByFindStr()
 		{
@@ -200,7 +196,6 @@ namespace ReferenceViewer
 			return false;
 		}
 		
-		[MenuItem("Assets/Find References In Project", false, 27)]
 		[MenuItem("Assets/Find References In Project/By GitGrep", false, 27)]
 		public static void FindReferencesByGitGrep()
 		{


### PR DESCRIPTION
以下の警告が発生しないようにした。
```
Cannot add menu item 'Assets/Find References In Project' for method 'ReferenceViewer.ReferenceViewerMenu.FindReferencesByGitGrep' because a menu item with the same name already exists.
UnityEditor.MenuService:GetMenuItemsFromAttributes ()
```